### PR TITLE
Converted Extension persistent background page to event page.

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -4,9 +4,17 @@ var jstorrent_lite_id = "abmohcnlldaiaodkpacnldcdnjjgldfh"
 var cws_url = "https://chrome.google.com/webstore/detail/"
 // TODO -- add jstorrent lite
 var createProps = {
+    id:"contextMenu",
     title:"Add to JSTorrent",
     contexts:["link"],
-    onclick: function(info, tab) {
+    targetUrlPatterns: ["magnet:*",
+                        "*://*/*.torrent",
+                        "*://*/*.torrent?*",
+                        "*://*/*.torrent#*"
+                       ]
+}
+
+function onContextMenuClickHandler(info, tab) {
         //console.log(info, tab)
 
         chrome.runtime.sendMessage(jstorrent_id, {command:'add-url',url:info.linkUrl, pageUrl:info.pageUrl}, function(result) {
@@ -25,20 +33,15 @@ var createProps = {
 
             // if no result, then try jstorrent lite ?
         })
-
-
-
-
-    },
-    targetUrlPatterns: ["magnet:*",
-                        "*://*/*.torrent",
-                        "*://*/*.torrent?*",
-                        "*://*/*.torrent#*"
-                       ]
-    
 }
-chrome.contextMenus.create(createProps, function() {
-    //console.log('created contextMenu')
+
+chrome.contextMenus.onClicked.addListener(onContextMenuClickHandler)
+
+// Set up context menu at install time.
+chrome.runtime.onInstalled.addListener(function() {
+    chrome.contextMenus.create(createProps, function() {
+        //console.log('created contextMenu')
+    })
 })
 
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,6 +23,7 @@
       ]
     },
     "background": {
+        "persistent": false,
         "scripts": ["background.js"]
     },
     "icons": { 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,19 +8,13 @@
     "minimum_chrome_version": "31",
     "permissions": [
         "contextMenus",
-        "notifications",
-        "*://*.jstorrent.com/*",
-        "*://jstorrent.com/*"
+        "notifications"
     ],
     "externally_connectable": {
-      "ids": [ 
-          "anhdpjpojoipgpmfanmedjghaligalgb",
-          "abmohcnlldaiaodkpacnldcdnjjgldfh"
-       ],
-      "matches": [
-          "*://*.jstorrent.com/*",
-          "*://jstorrent.com/*"
-      ]
+        "ids": [
+            "anhdpjpojoipgpmfanmedjghaligalgb",
+            "abmohcnlldaiaodkpacnldcdnjjgldfh"
+        ]
     },
     "background": {
         "persistent": false,


### PR DESCRIPTION
From http://developer.chrome.com/extensions/event_pages.html,
_Event pages are very similar to background pages, with one important difference: event pages are loaded only when they are needed. When the event page is not actively doing something, it is unloaded, freeing memory and other system resources._

It's pretty easy to do so. Let me know if it works for you.

![snp9upt](https://f.cloud.github.com/assets/634478/2120619/ea758c62-91bc-11e3-8488-6951ba2cf881.gif)
